### PR TITLE
#1 auto_install_archlinux.zsh: 仮想マシンでインストールに失敗する問題を修正

### DIFF
--- a/install_ArchLinux/auto_install_archlinux.zsh
+++ b/install_ArchLinux/auto_install_archlinux.zsh
@@ -7,19 +7,21 @@ zparseopts -D -M -A opthash -- \
     -hostname: \
     -device: \
     -swap: \
-    -boot:
+    -machine-type:
 
 if [[ -n "${opthash[(i)--help]}" ]]; then
     cat << EOF
 Automatically setup ArchLinux.
-Usage: zsh auto_install_archlinux.zsh [--help] [-h] [--hostname HOSTNAME] [--device DEVICE] [--swap SWAP_SIZE_GB] [--boot BOOT_PARTITION_TYPE]
+Usage: zsh auto_install_archlinux.zsh [--help] [-h] [--hostname HOSTNAME] [--device DEVICE] [--swap SWAP_SIZE_GB] [--machine-type TYPE]
 
 options:
     --help, -h: show this help.
     --hostname HOSTNAME: hostname for the installing ArchLinux
     --device DEVICE: device name install ArchLinux for (e.g: sda -> install for /dev/sda)
     --swap SWAP_SIZE_GB: size of swap partition. If 0, won't create a swap partition.
-    --boot BOOT_PARTITION_TYPE: /boot partition type (EF00 or EF02)
+    --machine-type TYPE: machine type, used for deciding boot partition type.
+        0 | Physical: create 0.5GB /boot partition as ESP
+        1 | Virtual:     create 2MB partition for boot loader (not mount as /boot)
 EOF
     exit
 fi
@@ -59,24 +61,40 @@ if [[ ! -e /dev/${DEVICE_DISK_INSTALL} ]]; then
     exit 1
 fi
 
-# partitions: boot, root and swap(optional)
+# Machine type
+# 0/Physical:   create 0.5GB /boot partition as ESP
+# 1/Virtual:    create 2MB partition for boot loader (not mount as /boot)
+if [[ -n "${opthash[(i)--machine-type]}" ]]; then
+    MACHINE_TYPE=${opthash[--machine-type]}
+else
+    vared -p "Machine type (0:Physical, 1:Virtual): " -c MACHINE_TYPE
+fi
+
+case "$MACHINE_TYPE" in
+    0 | Physical )
+        MACHINE_TYPE=Physical
+        ;;
+    1 | [vV]irtual )
+        MACHINE_TYPE=Virtual
+        ;;
+    * )
+        echo "Unknown machine type '${MACHINE_TYPE}'. Abort."
+        exit
+        ;;
+esac
+
+# swap size
 if [[ -n "${opthash[(i)--swap]}" ]]; then
     SWAP_SIZE_GB=${opthash[--swap]}
 else
     vared -p "Swap size at GiB (zero: won't create swap): " -c SWAP_SIZE_GB
 fi
 
-if [[ -n "${opthash[(i)--boot]}" ]]; then
-    BOOT_PARTITION_TYPE=${opthash[--boot]}
-else
-    vared -p "/boot partition type (Virtualbox/VMware: EF02, others: EF00): " -c BOOT_PARTITION_TYPE
-fi
-
 echo
 echo "Hostname: ${NEWHOSTNAME}"
 echo "Device for install: /dev/${DEVICE_DISK_INSTALL}"
 echo "Swap size: ${SWAP_SIZE_GB}GB"
-echo "/boot partition type: ${BOOT_PARTITION_TYPE}"
+echo "Machine type: ${MACHINE_TYPE}"
 
 read "?Continue? [Y/n]" Answer
 case $Answer in
@@ -90,15 +108,26 @@ esac
 set -exu
 
 # ==== setup storage
-if [[ -z $BOOT_PARTITION_TYPE ]]; then
-    # Virtualbox
-    PARTITION_BOOT_ID=
-    PARTITION_ROOT_ID=1
-else
-    # VMware or others
-    PARTITION_BOOT_ID=1
-    PARTITION_ROOT_ID=2
-fi
+case "$MACHINE_TYPE" in
+    Physical )
+        PARTITION_BOOT_ID=1
+        PARTITION_ROOT_ID=2
+        BOOT_PARTITION_TYPE=EF00
+        BOOT_PARTITION_SIZE_MB=512
+        ;;
+    Virtual )
+        PARTITION_BOOT_ID=1
+        PARTITION_ROOT_ID=2
+        BOOT_PARTITION_TYPE=EF02
+        BOOT_PARTITION_SIZE_MB=2
+        ;;
+    * )
+        echo "Unknown machine type '${MACHINE_TYPE}'. Abort."
+        exit
+        ;;
+esac
+
+
 if [[ SWAP_SIZE_GB -gt 0 ]]; then
     PARTITION_SWAP_ID=$(( $PARTITION_ROOT_ID + 1 ))
 else
@@ -108,40 +137,36 @@ fi
 sgdisk -o /dev/$DEVICE_DISK_INSTALL
 # /boot
 if [[ -n $PARTITION_BOOT_ID ]]; then
-    if [[ $BOOT_PARTITION_TYPE = EF00 ]]; then
-	BOOT_PARTITION_SIZE_MB=512
-    else
-	BOOT_PARTITION_SIZE_MB=2
-    fi
     sgdisk -n ${PARTITION_BOOT_ID}::${BOOT_PARTITION_SIZE_MB}M -t ${PARTITION_BOOT_ID}:${BOOT_PARTITION_TYPE} /dev/$DEVICE_DISK_INSTALL
 fi
 
 # /root, swap
 if [[ SWAP_SIZE_GB -gt 0 ]]; then
-    # /dev/xxx2: root, /dev/xxx3: swap
     sgdisk -n ${PARTITION_ROOT_ID}::-${SWAP_SIZE_GB}G -t ${PARTITION_ROOT_ID}:8300 /dev/$DEVICE_DISK_INSTALL
     sgdisk -n ${PARTITION_SWAP_ID}::                  -t ${PARTITION_SWAP_ID}:8200 /dev/$DEVICE_DISK_INSTALL
 else
-    # /dev/xxx2: root
     sgdisk -n ${PARTITION_ROOT_ID}:: -t ${PARTITION_ROOT_ID}:8300 /dev/$DEVICE_DISK_INSTALL
 fi
 sgdisk -p /dev/$DEVICE_DISK_INSTALL
 
+# make filesystem, mount
 PARTITION_ROOT=/dev/${DEVICE_DISK_INSTALL}${PARTITION_ROOT_ID}
 mkfs.ext4 $PARTITION_ROOT
 mount $PARTITION_ROOT /mnt
 if [[ -n $PARTITION_BOOT_ID ]]; then
     PARTITION_BOOT=/dev/${DEVICE_DISK_INSTALL}${PARTITION_BOOT_ID}
     mkfs.vfat -F32 $PARTITION_BOOT
-    mkdir -p /mnt/boot
-    mount $PARTITION_BOOT /mnt/boot
+    if [[ $BOOT_PARTITION_TYPE = EF00 ]]; then
+        # EF00 (ESP) -> mount as /boot
+        mkdir -p /mnt/boot
+        mount $PARTITION_BOOT /mnt/boot
+    fi
 fi
 if [[ -n $PARTITION_SWAP_ID ]]; then
     PARTITION_SWAP=/dev/${DEVICE_DISK_INSTALL}${PARTITION_SWAP_ID}
     mkswap $PARTITION_SWAP
     swapon $PARTITION_SWAP
 fi
-
 
 
 # ==== Install base system
@@ -168,10 +193,10 @@ ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 pacman -S --noconfirm grub vim net-tools openssh os-prober efibootmgr
 echo -e "en_US.UTF-8 UTF-8\nja_JP.UTF-8 UTF-8" >> /etc/locale.gen
 locale-gen
-echo "LANG=ja_JP.UTF-8" >> /etc/locale.conf
+echo "LANG=en_US.UTF-8" >> /etc/locale.conf
 echo -e 'KEYMAP=jp106\nFONT=Lat2-Terminus16' > /etc/vconsole.conf
 systemctl enable dhcpcd.service
-echo root:$NEWROOTPASS | chpasswd
+echo "root:${NEWROOTPASS}" | chpasswd
 EOF
 
 
@@ -194,7 +219,8 @@ fi
 chmod +x /mnt$CHROOT_SETUP_SCRIPT
 arch-chroot /mnt $CHROOT_SETUP_SCRIPT
 
-if [[ -n $PARTITION_BOOT_ID ]]; then
+if [[ $BOOT_PARTITION_TYPE = EF00 ]]; then
     umount $PARTITION_BOOT
 fi
 umount $PARTITION_ROOT
+reboot


### PR DESCRIPTION
仮想マシンの場合は、boot loader用パーティションを`/boot`にmountしないようにした